### PR TITLE
Make digestif working with ConTeXt standalone installation

### DIFF
--- a/bin/digestif
+++ b/bin/digestif
@@ -2,4 +2,14 @@
 -- Remove relative directories from package path
 package.path = package.path:gsub("%f[^\0;]%.[^;]*", ""):gsub(";+", ";"):gsub("^;", ""):gsub(";$", "")
 package.cpath = package.cpath:gsub("%f[^\0;]%.[^;]*", ""):gsub(";+", ";"):gsub("^;", ""):gsub(";$", "")
+
+-- this looks like peculiarity of LuaTeX and ConTeXt specifically its script runner
+-- when I run 'texlua <name> $@' it passes the name of the script as the first argument
+
+-- if first element of arg matches the full path of this file name, remove it
+local fullpath = debug.getinfo(1,"S").source:sub(2)
+if arg[1] == fullpath then
+  table.remove(arg, 1)
+end
+
 require "digestif.langserver".main(arg)

--- a/digestif/util.lua
+++ b/digestif/util.lua
@@ -391,8 +391,8 @@ local is_command_cmd = util.os_type == "windows"
 -- Return `name` if an executable with that name exists, nil
 -- otherwise.
 local function is_command(name)
-  local ok = os.execute(format(is_command_cmd, name))
-  return ok and name or nil
+  local ok, err = pcall(os.execute, format(is_command_cmd, name)))
+  return err == 0 and ok and name or nil
 end
 util.is_command = is_command
 

--- a/digestif/util.lua
+++ b/digestif/util.lua
@@ -391,7 +391,7 @@ local is_command_cmd = util.os_type == "windows"
 -- Return `name` if an executable with that name exists, nil
 -- otherwise.
 local function is_command(name)
-  local ok, err = pcall(os.execute, format(is_command_cmd, name)))
+  local ok, err = pcall(os.execute, format(is_command_cmd, name))
   return err == 0 and ok and name or nil
 end
 util.is_command = is_command


### PR DESCRIPTION
I have a [ConTeXt standalone installation](https://wiki.contextgarden.net/index.php?title=ConTeXt_Standalone). The caveat is   it relies on `LuaMetaTex` and  Lua scripts instead of prograps that come with TeX Live installation, s.a. `kpsewhich` and `texlua`.  To make `digestif` work for me I had to alter the code a little bit. 